### PR TITLE
fix alpha discrete logic bug in getColorByGradient()

### DIFF
--- a/src/component/DataRange.js
+++ b/src/component/DataRange.js
@@ -231,7 +231,7 @@ util.extend(DataRange.prototype, {
         index = parseInt(index, 10);
         index *= 4;
 
-        var color = 'rgba(' + this._grad[index] + ', ' + this._grad[index + 1] + ', ' + this._grad[index + 2] + ',' + this._grad[index + 3] +')';
+        var color = 'rgba(' + this._grad[index] + ', ' + this._grad[index + 1] + ', ' + this._grad[index + 2] + ',' + (this._grad[index + 3] / 255) +')';
         return color;
     }
 


### PR DESCRIPTION
生成'rgba(r,g,b,a)'字符串时，a的值应当还原成0-1的区间;
之前是0-255的，导致离散后渐变色的alpha往往是>1，于是基本不能半透明。

没写过前端代码哈，只有简单自测通过，烦请各位看看。