### PR TITLE
fix: 防止 Event.prototype 被修改

### DIFF
--- a/src/data/DataSet.js
+++ b/src/data/DataSet.js
@@ -47,7 +47,7 @@ function DataSet(data, options) {
 
 }
 
-DataSet.prototype = Event.prototype;
+DataSet.prototype = Object.create(Event.prototype);
 
 /**
  * Add data.


### PR DESCRIPTION
直接 ``DataSet.prototype = Event.prototype`` 会导致后面 ``Event.prototype`` 被修改