### PR TITLE
Mapv ol pr

### DIFF
--- a/examples/openlayers/ol-point-icon-projection.html
+++ b/examples/openlayers/ol-point-icon-projection.html
@@ -1,0 +1,103 @@
+﻿<!DOCTYPE html>
+<html>
+
+<head>
+	<title>ol-point-colorpleth</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/openlayers/dist/ol.css">
+	<style>
+		html,
+		body,
+		#map {
+			height: 100%;
+			padding: 0;
+			margin: 0;
+		}
+	</style>
+</head>
+
+<body>
+	<div id="map"></div>
+	<script src="https://cdn.jsdelivr.net/npm/openlayers/dist/ol.js"></script>
+	<script src="../../build/mapv.js"></script>
+	<script>
+		var map = new ol.Map({
+			target: 'map',
+			layers: [
+				new ol.layer.Tile({
+					layerName: 'baseLayer',
+					preload: 4,
+					source: new ol.source.OSM({
+						url: 'http://{a-e}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
+					})
+				})
+			],
+			loadTilesWhileAnimating: true,
+			pixelRatio: 1,
+			view: new ol.View({
+				// projection: 'EPSG:4326',
+				// center: [-102.17609405517578, 34.41583177128595],
+				projection: 'EPSG:3857',
+				center: ol.proj.transform([-102.17609405517578, 34.41583177128595], 'EPSG:4326',
+					"EPSG:3857"),
+				zoom: 5
+			})
+		});
+
+		var randomCount = 300;
+		var data = [];
+
+		var img = new Image();
+		img.src = '../images/flag.png';
+
+		img.onload = function () {
+			// 构造数据
+			while (randomCount--) {
+				data.push({
+					geometry: {
+						type: 'Point',
+						// coordinates: ol.proj.transform([-125.8 + Math.random() * 50, 30.3 + Math.random() * 20],
+						// 	'EPSG:4326',
+						// 	"EPSG:3857")
+						coordinates: [-125.8 + Math.random() * 50, 30.3 + Math.random() * 20]
+					},
+					deg: 360 * Math.random(),
+					icon: img
+				});
+			}
+
+			var dataSet = new mapv.DataSet(data);
+
+			var baseSize = {
+				width: 24,
+				height: 30
+			};
+
+
+			var options = {
+				draw: 'icon',
+				// projection是dataSet中数据的投影类型 可以与map.view中的类型不同 会自动转换 但对性能有一定的影响 所以尽量让数据与map的类型一致
+				// projection: 'EPSG:3857',
+				projection: 'EPSG:4326',
+				width: baseSize.width,
+				height: baseSize.height,
+				methods: {
+					click: function (event) {
+						console.log(event)
+					},
+					mousemove: function (event) {
+						if (event) {
+							mapvLayer.setDefaultCursor('pointer', event)
+						} else {
+							mapvLayer.setDefaultCursor('default', event)
+						}
+					}
+				}
+			};
+			var mapvLayer = new mapv.OpenlayersLayer(map, dataSet, options);
+		}
+	</script>
+</body>
+
+</html>

--- a/src/map/openlayers-map/Layer.js
+++ b/src/map/openlayers-map/Layer.js
@@ -97,6 +97,7 @@ class Layer extends BaseLayer {
     const context = canvas.getContext(this.context);
     const animationOptions = this.options.animation;
     const _projection = this.options.hasOwnProperty('projection') ? this.options.projection : 'EPSG:4326';
+    const mapViewProjection = this.$Map.getView().getProjection().getCode();
     if (this.isEnabledTime()) {
       if (time === undefined) {
         clear(context);
@@ -120,11 +121,14 @@ class Layer extends BaseLayer {
     } else {
       context.clear(context.COLOR_BUFFER_BIT);
     }
-    const dataGetOptions = {
-      transferCoordinate: function(coordinate) {
-        return map.getPixelFromCoordinate(ol.proj.transform(coordinate, _projection, 'EPSG:4326'));
-      }
-    };
+	const dataGetOptions = {}
+    dataGetOptions.transferCoordinate = ((_projection === mapViewProjection) ? function (coordinate) {
+			// 当数据与map的投影一致时不再进行投影转换
+			return map.getPixelFromCoordinate(coordinate);
+		} : function (coordinate) {
+			// 数据与Map投影不一致时 将数据投影转换为 Map的投影
+			return map.getPixelFromCoordinate(ol.proj.transform(coordinate, _projection, mapViewProjection));
+		});
 
     if (time !== undefined) {
       dataGetOptions.filter = function(item) {
@@ -175,7 +179,7 @@ class Layer extends BaseLayer {
         extent: extent,
         source: new ol.source.ImageCanvas({
           canvasFunction: this.canvasFunction.bind(this),
-          projection: (this.options.hasOwnProperty('projection') ? this.options.projection : 'EPSG:4326'),
+          projection: this.$Map.getView().getProjection().getCode(), // 图层投影与Map保持一致
           ratio: (this.options.hasOwnProperty('ratio') ? this.options.ratio : 1)
         })
       });

--- a/src/map/openlayers-map/Layer.js
+++ b/src/map/openlayers-map/Layer.js
@@ -329,6 +329,20 @@ class Layer extends BaseLayer {
       this.previousCursor_ = undefined
     }
   }
+  
+  /**
+   * 显示图层
+   */
+  show() {
+    this.$Map.addLayer(this.layer_);
+  }
+
+  /**
+   * 隐藏图层
+   */
+  hide() {
+    this.$Map.removeLayer(this.layer_);
+  }
 }
 
 export default Layer


### PR DESCRIPTION
只针对openlayer中的Layer进行了小部分的修改
主要修改：
1 添加 显示 隐藏图层方法
2 修改投影相关

之前使用mapv+openlayer时 如果底图使用 非wgs84，并且移动时会出现点位置不在正确位置上的情况
主要是为了修复这类异常情况 以适应 不同投影的底图和数据